### PR TITLE
Update pdk before running real command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ else
   additional_opts=""
 fi
 
-pdk test unit --format=text $additional_opts
+pdk update && pdk test unit --format=text $additional_opts


### PR DESCRIPTION
Fix message 
```
pdk (FATAL): Fetching gem metadata from https://rubygems.org/........

Could not find gem 'puppet-module-posix-default-r3.2 (~> 1.0)' in rubygems
repository https://rubygems.org/ or installed locally.

pdk (FATAL): Unable to resolve Gemfile dependencies

```